### PR TITLE
chore: change dependency installation to use --no-frozen-lockfile

### DIFF
--- a/.github/workflows/debug.yml
+++ b/.github/workflows/debug.yml
@@ -28,7 +28,7 @@ jobs:
           cache: "pnpm"
 
       - name: Install dependencies
-        run: pnpm install --frozen-lockfile
+        run: pnpm install --no-frozen-lockfile
 
       - name: Run lint
         run: pnpm lint

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -38,7 +38,7 @@ jobs:
           cache: "pnpm"
 
       - name: Install dependencies
-        run: pnpm install --frozen-lockfile
+        run: pnpm install --no-frozen-lockfile
 
       - name: Verify the integrity of provenance attestations and registry signatures for installed dependencies
         run: pnpm audit signatures


### PR DESCRIPTION
This pull request includes changes to the GitHub workflows to modify how dependencies are installed. The most important changes are:

Changes to dependency installation:

* [`.github/workflows/debug.yml`](diffhunk://#diff-22ec448956849a92b29ee757943a6d9f51b5fbf9ae7cabbe309d2a5acc560ca4L31-R31): Changed the `Install dependencies` step to use `--no-frozen-lockfile` instead of `--frozen-lockfile` in the `pnpm install` command.
* [`.github/workflows/release.yml`](diffhunk://#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34L41-R41): Changed the `Install dependencies` step to use `--no-frozen-lockfile` instead of `--frozen-lockfile` in the `pnpm install` command.…workflows